### PR TITLE
fix version import for environments like buildout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,15 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com rafael@caricio.com
 
-
+import os
 from setuptools import setup
-from tornado_pyvows.version import __version__
+from imp import load_source
+
+version = load_source('version', os.path.join("tornado_pyvows", "version.py"))
 
 setup(
     name = 'tornado_pyvows',
-    version = '.'.join([str(item) for item in __version__]),
+    version = '.'.join([str(item) for item in version.__version__]),
     description = "tornado_pyvows are pyvows extensions to tornado web framework.",
     long_description = """
 tornado_pyvows are pyvows extensions to tornado web framework.


### PR DESCRIPTION
Hi Rafael,

again a little fix. When I want to use tornado_pyvows with buildout (e.g.) I cannot install it since I do not have a system wide Tornado installed. So installation stops with an `ImportError: No module named tornado.ioloop`.

With this patch we load the `version.py` manually in the `setup.py` and the `tornado_pyvows` module is not loaded completely.

If you have no objections I would simply add this for the next release!

Best
Daniel
