### PR TITLE
Add mock to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyvows
 tornado
 pycurl
 urllib3
+mock


### PR DESCRIPTION
Hi, I found I had to add this to run the tests on Python 2.7. Mock is not part of standard library until python 3.3. Perhaps others just add it or have it installed system wide?
