### PR TITLE
Pyvows 2.0.5 has broken tornado_pyvows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ python:
 before_install:
     sudo apt-get install -y libevent-dev python-gevent python-lxml
 install:
-    pip install -r requirements.txt --use-mirrors
+    make setup
 script:
     make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
 
 test:
 	@env PYTHONPATH=. pyvows vows/
+
+setup:
+	@pip install -Ue.\[test\]

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ tornado_pyvows are pyvows extensions to tornado web framework.
         'test': tests_require,
     },
     install_requires=[
-        "pyvows",
+        "pyvows<=2.0.3",
         "tornado",
         "pycurl",
         "urllib3"

--- a/tornado_pyvows/version.py
+++ b/tornado_pyvows/version.py
@@ -8,4 +8,4 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 Rafael Caricio rafael@caricio.com
 
-__version__ = (0, 5, 2)
+__version__ = (0, 5, 3)


### PR DESCRIPTION
Pyvows's new release has broken tornado_pyvows.

```
tornado_pyvows git:(master) ✗ pyvows vows/basecontext_vows.py

 ============
 Vows Results
 ============

    Async vows

     Error in topic:
    'NoneType' object is not callable

Traceback (most recent call last):
      File "/Users/guilhermef/.virtualenvs/tornado_pyvows/lib/python2.7/site-packages/pyvows/runner/gevent.py", line 101, in _run_setup_and_topic
    topic = topic_func(*topic_list)
TypeError: 'NoneType' object is not callable

    Nested tests following this error have not been run.
  ✓ OK » 0 honored • 0 broken (0.000431s)
```
