### PR TITLE
setup.py: Loosen the pyVows dependency to blacklist only 2.0.4 and 2.0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ tornado_pyvows are pyvows extensions to tornado web framework.
         'test': tests_require,
     },
     install_requires=[
-        "pyvows<=2.0.3",
+        "pyvows !=2.0.4, !=2.0.3",
         "tornado",
         "pycurl",
         "urllib3"


### PR DESCRIPTION
1d264b96 (Pyvows 2.0.5 has broken tornado_pyvows, 2014-05-19)
mentioned pyVows 2.0.5, but also blocked 2.0.4.  Since then, there has
been a 2.0.6 release which fixes this issue 59e67374 (topics can be
none, we need to validate against that, 2014-06-02, [1](https://github.com/heynemann/pyvows/commit/59e67374bcfbf7c8c45a4be575e8eae64902c209)).  Instead of
ignoring all future pyVows development, only blacklist the versions we
know to be broken.  Well, I haven't actually tested with 2.0.4, but we
should be allowing 2.0.6 (which I have tested) and later.
